### PR TITLE
Update test to use requests instead of pycurl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - docker build -t max-image-caption-generator .
   - docker run -it -d -p 5000:5000 max-image-caption-generator
 before_script:
-  - pip install pytest pycurl
+  - pip install pytest requests
 script:
   - pytest tests/test.py

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,25 +1,20 @@
 import pytest
-import pycurl
-import io
-import json
+import requests
 
 
 def test_response():
-    c = pycurl.Curl()
-    b = io.BytesIO()
-    c.setopt(pycurl.URL, 'http://localhost:5000/model/predict')
-    c.setopt(pycurl.HTTPHEADER, ['Accept:application/json', 'Content-Type: multipart/form-data'])
-    c.setopt(pycurl.HTTPPOST, [('image', (pycurl.FORM_FILE, "assets/surfing.jpg"))])
-    c.setopt(pycurl.WRITEFUNCTION, b.write)
-    c.perform()
-    assert c.getinfo(pycurl.RESPONSE_CODE) == 200
-    c.close()
+    model_endpoint = 'http://localhost:8088/model/predict'
+    file_path = 'assets/surfing.jpg'
+    caption_text = 'a man riding a wave on top of a surfboard .'
 
-    response = b.getvalue()
-    response = json.loads(response)
+    with open(file_path, 'rb') as file:
+        file_form = {'file': (file_path, file, 'image/jpeg')}
+        r = requests.post(url=model_endpoint, files=file_form)
 
+    assert r.status_code == 200
+    response = r.json()
     assert response['status'] == 'ok'
-    assert response['predictions'][0]['caption'] == 'a man riding a wave on top of a surfboard .'
+    assert response['predictions'][0]['caption'] == caption_text
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As noted in https://github.com/IBM/MAX-Image-Caption-Generator-Web-App/pull/40 `requests` is a more "standard" http library than `pycurl` and is the library used in the related web app. It also tends to be less verbose.